### PR TITLE
Add support for Eclair (API 7) devices

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "io.tus.android.example"
-        minSdkVersion 15
+        minSdkVersion 7
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "io.tus.android.example"
-        minSdkVersion 7
+        minSdkVersion 15
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"

--- a/tus-android-client/build.gradle
+++ b/tus-android-client/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 1
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"

--- a/tus-android-client/build.gradle
+++ b/tus-android-client/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 1
+        minSdkVersion 4
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"

--- a/tus-android-client/build.gradle
+++ b/tus-android-client/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 7
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"

--- a/tus-android-client/build.gradle
+++ b/tus-android-client/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 4
+        minSdkVersion 7
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"

--- a/tus-android-client/src/main/java/io/tus/android/client/TusPreferencesURLStore.java
+++ b/tus-android-client/src/main/java/io/tus/android/client/TusPreferencesURLStore.java
@@ -1,6 +1,7 @@
 package io.tus.android.client;
 
 import android.content.SharedPreferences;
+import android.os.Build;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -46,7 +47,11 @@ public class TusPreferencesURLStore implements TusURLStore {
 
         SharedPreferences.Editor editor = preferences.edit();
         editor.putString(fingerprint, urlStr);
-        editor.apply();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+            editor.apply();
+        } else {
+            editor.commit();
+        }
     }
 
     public void remove(String fingerprint) {
@@ -54,9 +59,12 @@ public class TusPreferencesURLStore implements TusURLStore {
         if(fingerprint.length() == 0) {
             return;
         }
-
         SharedPreferences.Editor editor = preferences.edit();
         editor.remove(fingerprint);
-        editor.apply();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+            editor.apply();
+        } else {
+            editor.commit();
+        }
     }
 }


### PR DESCRIPTION
We want to use the TUS client in our application, which supports Froyo (API 8) and later devices. Changing the min SDK to API 7 required a very minor change.

*Note*: the client doesn't appear to use the `com.android.support:appcompat-v7` library. If the library is removed, this `minSdkVersion` can be changed to 4.