### PR TITLE
Upgrade to Gradle 8.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   android:
     strategy:
       matrix:
-        java: [ '11','19' ]
+        java: [ '17','21' ]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -23,6 +23,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+    namespace 'io.tus.android.example'
 }
 
 dependencies {

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.tus.android.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,9 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
+
+# Build settings (needed for upgrades of the Android Gradle plugin)
+android.defaults.buildfeatures.buildconfig=false
+android.enableR8.fullMode=true
+android.nonTransitiveRClass=true
+android.nonFinalResIds=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/tus-android-client/build.gradle
+++ b/tus-android-client/build.gradle
@@ -35,23 +35,29 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 }
 
-tasks.register('sourcesJar', Jar) {
-    archiveClassifier.set('sources')
-    from android.sourceSets.main.java.srcDirs
-}
-
-tasks.register('javadoc', Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    android.libraryVariants.all { variant ->
-        owner.classpath += variant.javaCompileProvider.get().classpath
+afterEvaluate {
+    tasks.register('sourcesJar', Jar) {
+        archiveClassifier.set('sources')
+        from android.sourceSets.main.java.srcDirs
     }
-}
 
-tasks.register('javadocJar', Jar) {
-    dependsOn javadoc
-    archiveClassifier.set('javadoc')
-    from javadoc.destinationDir
+    tasks.register('javadoc', Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        android.libraryVariants.all { variant ->
+            owner.classpath += variant.javaCompileProvider.get().classpath
+        }
+    }
+
+    tasks.register('javadocJar', Jar) {
+        dependsOn javadoc
+        archiveClassifier.set('javadoc')
+        from javadoc.destinationDir
+    }
+
+    artifacts {
+        archives sourcesJar, javadocJar
+    }
 }
 
 def pomConfig = {
@@ -93,6 +99,9 @@ publishing {
 
                 artifact sourcesJar
                 artifact javadocJar
+                artifact (project.layout.buildDirectory.dir('outputs/aar/tus-android-client-release.aar')) {
+                    builtBy assemble
+                }
 
                 pom.withXml {
                     def root = asNode()

--- a/tus-android-client/build.gradle
+++ b/tus-android-client/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion '30.0.3'
+    compileSdk 33
+    setBuildToolsVersion("30.0.3")
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 33
+        targetSdk 33
     }
     buildTypes {
         release {
@@ -21,6 +21,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+    namespace 'io.tus.android.client'
 }
 
 def config = new ConfigSlurper().parse(new File("${projectDir}/src/main/res/tus-android-client-version/version.properties").toURI().toURL())
@@ -34,12 +35,12 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 }
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
 }
 
-task javadoc(type: Javadoc) {
+tasks.register('javadoc', Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     android.libraryVariants.all { variant ->
@@ -47,7 +48,8 @@ task javadoc(type: Javadoc) {
     }
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
+tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
     archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
@@ -83,7 +85,7 @@ publishing {
     publications {
         androidRelease(MavenPublication) {
             afterEvaluate {
-                from components.release
+                from components.findByName('release')
                 groupId 'io.tus.android.client'
                 artifactId 'tus-android-client'
                 description project.getDescription()

--- a/tus-android-client/build.gradle
+++ b/tus-android-client/build.gradle
@@ -70,6 +70,11 @@ def pomConfig = {
             name 'Marius Kleidl'
             email 'marius@transloadit.com'
         }
+        developer {
+            id 'cdr-chakotay'
+            name 'Florian Kuenzig'
+            email 'florian@transloadit.com'
+        }
     }
 
     inceptionYear '2015'

--- a/tus-android-client/src/main/AndroidManifest.xml
+++ b/tus-android-client/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.tus.android.client">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
1.)First Upgrade to Gradle 8.4 
- Upgrade Gradle itself
- Update Manifest files and use namespaces instead. => Now package info is injected dynamically
- Upgrade Android Gradle plugin to newest version under the following requirements:
    - `android.defaults.buildfeatures.buildconfig=false`
    - `android.enableR8.fullMode=true`
    - `android.nonTransitiveRClass=true`
    - `android.nonFinalResIds=true`

2.)Then Upgrade to Gradle 8.6
3.) Define a Gradle task to include AAR builds inside the release.
4.) Bumped up Java to Version 17 and 21 for CI Operations (minimum of Java 17 is required by the Android Gralde Plugin)

Added myself to the maintainers of this, we can also skip that if you want :)