### PR TITLE
Replace Slack notification action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: failure
+      - name: Send Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_TEXT: >-
+            ${{ github.workflow }} failed for ${{ github.repository }} on ${{ github.ref_name }}:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node -e "process.stdout.write(JSON.stringify({ text: process.env.SLACK_TEXT }))" |
+            curl --fail-with-body -X POST -H 'Content-type: application/json' --data-binary @- "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Why

Reduce GitHub Actions supply-chain exposure by removing the third-party Slack notification action from the CI failure path.

What changed

- Replaces `8398a7/action-slack` with a direct incoming-webhook `curl` step.
- Keeps notifications scoped to main-branch Android CI failures.

Validation

- Ruby YAML parse for `.github/workflows/CI.yml`
- `git diff --check`